### PR TITLE
Organize documentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,62 +13,13 @@ By running your command through `ea`, each path in its output get marked with a 
 number can be used to retrieve its corresponding path later for your purposes. Combined with some shell
 configurations, this can provide a powerful experience.
 
-## Shell integration
+## Documentations
 
-First, you'll want alias your normal command to the `ea` version:
-
-```fish
-alias fd 'ea run linear fd --' # more explanation on this syntax later
-```
-
-Then, optionally, make a shell function that consume a path from `ea`'s output.
-
-```fish
-# calling `e N` makes nvim opens Nth location stored by `ea`.
-function e
-    eval (ea print $argv 'nvim \"{path}\" \"+call cursor({line}, {column})\"')
-end
-```
-
-## Subcommands, explained
-
-`ea` provides 3 subcommands that compliment each other.
-
-### `ea run`
-
-Run a command, add annotation to paths included in its output, and store each path for later use. `ea` expects
-a hint for your command's output format. It must be one of the following:
-
-1. linear
-2. grouped
-3. search
-
-The specifics of these formats is explained in [formats][].
-
-For example, `ripgrep`'s default output format matches the `grouped` style, so you'd run:
-
-```
-ea run grouped rg ...
-```
-
-All command line arguments for the actual command must follow `--`. Furthering our example, this is how to run
-`rg Vec` with `ea`:
-
-```
-ea run grouped rg -- Vec
-```
-
-### `ea print`
-
-Alternatively, `ea p`. This command prints out a stored location. You tell it which location number to print,
-and, optionally, what format to print it in. First example, `ea p 3` will print out the 3rd location. And
-`ea print 1 '{path} L{line} C{column}'` might print something like `a/b/c.swift L23 C15`. The second argument
-is a format string where `{path}` / `{line}` / `{column}` get replaced by corresponding values.
-
-
-### `ea list`
-
-Or simply `ea`. This subcommand prints out a list of stored locations with their associated numbers.
+* [User Manual](docs/UserManual.md)
+    * [Tutorial](docs/UserManual.md#description)
+    * [Formats](docs/UserManual.md#formats)
+    * [Shell Integration](docs/UserManual.md#shell-integration)
+* [Note to packagers](docs/Packaging.md)
 
 ## Credits
 

--- a/docs/UserManual.md
+++ b/docs/UserManual.md
@@ -77,6 +77,27 @@ FORMATS
 
 If you need `ea` to support more formats, please file an issue at https://github.com/dduan/ea
 
+SHELL INTEGRATION
+-----------------
+
+Some shell aliases, and functions makes using `ea` more effective.
+
+First, you'll want alias your normal command to the `ea` version:
+
+```
+alias fd 'ea run linear fd --'
+```
+
+Then, optionally, make a shell function that consume a path from `ea`'s output. The following example makes `e 6` opens the 6th paths known to `ea` in your default editor in zsh/bash:
+
+```
+e() {  
+    eval $(ea p $1 "$EDITOR {path}")  
+}
+```
+
+For more examples, see documentation at https://github.com/dduan/ea
+
 AUTHOR
 ------
 

--- a/docs/ea.1
+++ b/docs/ea.1
@@ -172,6 +172,34 @@ public let filePath: Stringx
 .PP
 If you need \f[V]ea\f[R] to support more formats, please file an issue
 at https://github.com/dduan/ea
+.SS SHELL INTEGRATION
+.PP
+Some shell aliases, and functions makes using \f[V]ea\f[R] more
+effective.
+.PP
+First, you\[cq]ll want alias your normal command to the \f[V]ea\f[R]
+version:
+.IP
+.nf
+\f[C]
+alias fd \[aq]ea run linear fd --\[aq]
+\f[R]
+.fi
+.PP
+Then, optionally, make a shell function that consume a path from
+\f[V]ea\f[R]\[cq]s output.
+The following example makes \f[V]e 6\f[R] opens the 6th paths known to
+\f[V]ea\f[R] in your default editor in zsh/bash:
+.IP
+.nf
+\f[C]
+e() {  
+    eval $(ea p $1 \[dq]$EDITOR {path}\[dq])  
+}
+\f[R]
+.fi
+.PP
+For more examples, see documentation at https://github.com/dduan/ea
 .SS AUTHOR
 .PP
 Daniel Duan <daniel@duan.ca>


### PR DESCRIPTION
Link to external docs in README.
Move shell integration to user manual.

Closes #5