### PR TITLE
Improve inter-process error signaling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /result
+/.vscode

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -44,7 +44,8 @@ impl fmt::Display for RunError {
 
 impl error::Error for RunError {}
 
-static ERROR_SIGNAL: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
+// deliberately mis-spelled
+static ERROR_SIGNAL: [u8; 4] = [0xde, 0xad, 0xbe, 0xaf];
 
 fn format_error(is_tty: bool, error: Box<dyn error::Error>) -> String {
     if is_tty {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -13,12 +13,31 @@ use std::process;
 #[derive(Debug)]
 enum RunError {
     CouldNotExecuteCommand(String),
+    CommandEncounteredError(String),
+    CommandWasInterrupted(String),
+}
+
+impl RunError {
+    fn new(code: u8, command: &str) -> Option<Self> {
+        match code {
+            0 => Some(Self::CouldNotExecuteCommand(command.to_string())),
+            1 => Some(Self::CommandEncounteredError(command.to_string())),
+            2 => Some(Self::CommandWasInterrupted(command.to_string())),
+            _ => None,
+        }
+    }
+
+    fn could_not_execute_command() -> u8 { 0 }
+    fn command_encountered_error() -> u8 { 1 }
+    fn command_was_interrupted() -> u8 { 2 }
 }
 
 impl fmt::Display for RunError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             RunError::CouldNotExecuteCommand(command) => write!(f, "could not execute {}", command),
+            RunError::CommandEncounteredError(command) => write!(f, "{} encountered an error", command),
+            RunError::CommandWasInterrupted(command) => write!(f, "{} was interrupted by signal", command),
         }
     }
 }
@@ -38,17 +57,13 @@ fn format_error(is_tty: bool, error: Box<dyn error::Error>) -> String {
 pub fn run(style: &Style, executable: &str, arguments: &[String], debug: Option<String>) {
     let is_tty = atty::is(atty::Stream::Stdout);
     let output = execute(is_tty, executable, arguments);
-    if output.len() >= 4 && output[..4] == ERROR_SIGNAL {
-        _ = io::stderr().write(
-            format_error(
-                is_tty,
-                Box::new(RunError::CouldNotExecuteCommand(executable.to_string())),
-            )
-            .as_bytes(),
-        );
-        _ = io::stderr().write(&output[5..]);
+    let output_len = output.len();
+    if output_len >= 4 && output[(output_len - 4)..] == ERROR_SIGNAL {
+        let error = RunError::new(output[output_len - 5], executable).expect("Error synthesized");
+        _ = io::stderr().write(format_error(is_tty, Box::new(error)).as_bytes());
+        _ = io::stderr().write(&output[0..(output_len - 6)]);
         eprintln!();
-        process::exit(output[4] as i32);
+        process::exit(output[output_len - 6] as i32);
     }
 
     let parsed = match style {
@@ -83,32 +98,38 @@ fn execute_simple(executable: &str, arguments: &[String], output: &mut Vec<u8>) 
     // We must run with .status() as opposed to .output() because we might be in a pty.
     // Running .output() would convince the process it's not in a pty!
     let execution_result = process::Command::new(executable).args(arguments).status();
+
+    let error_code: u8;
+    let exit: u8;
     match execution_result {
         Ok(exit_status) => {
             if let Some(exit_code) = exit_status.code() {
-                if exit_code != 0 {
-                    output.extend_from_slice(&ERROR_SIGNAL);
-                    output.push(exit_code as u8);
-                    // TODO: better explanation?
-                    output.extend_from_slice(b"an unknown error happend during execution");
-                }
-                return exit_code;
-            } // TODO: else ??????
+                exit = exit_code as u8;
+                // if exit is 0, this following error won't really be used later.
+                error_code = RunError::command_encountered_error();
+            } else {
+                exit = 1;
+                error_code = RunError::command_was_interrupted();
+            }
         }
         Err(error) => {
-            // We are in a child process, whose entire output will be read by the parent.
-            // To signal to the parent that something went wrong, we print out a special
-            // sequence at the start of the output, followed by an error code.
-            // Any error produced by the external command is attached after the error
-            // signal sequence.
-            output.extend_from_slice(&ERROR_SIGNAL);
-            output.push(error.raw_os_error().unwrap_or(1) as u8);
             output.extend_from_slice(error.to_string().as_bytes());
-            return 1;
+            exit = error.raw_os_error().unwrap_or(1) as u8;
+            error_code = RunError::could_not_execute_command();
         }
     }
 
-    0
+    // We are in a child process, whose entire output will be read by the parent.  To signal to the
+    // parent that something went wrong, we print out a special sequence at the end of the output,
+    // proceeded by an error code, proceeded by an exit status.  Any error produced by the external
+    // command is attached after the error signal sequence.
+    if exit != 0 {
+        output.push(exit);
+        output.push(error_code);
+        output.extend_from_slice(&ERROR_SIGNAL);
+    }
+
+    exit as i32
 }
 
 fn execute(is_tty: bool, executable: &str, arguments: &[String]) -> Vec<u8> {

--- a/src/parsers/rust.rs
+++ b/src/parsers/rust.rs
@@ -16,8 +16,7 @@ pub fn rust(input: &[u8]) -> Result<(Vec<u8>, Vec<Location>), ParseError> {
 mod tests {
     use super::rust;
     use crate::archive::read_from;
-    use crate::parsers::tests::fixture;
-    use crate::Location;
+    use crate::{parsers::tests::fixture, Location};
     use std::fs;
 
     #[test]

--- a/tests/intergation_tests.rs
+++ b/tests/intergation_tests.rs
@@ -1,6 +1,6 @@
 use assert_cmd::prelude::CommandCargoExt;
 use std::path::PathBuf;
-use std::process::Command;
+use std::process;
 use std::io::Read;
 use pty::fork::Fork;
 
@@ -11,8 +11,8 @@ fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 #[test]
 // Run `ea run` in a terminal with a sample app. Check output is reasonably modified by `ea`.
 fn invoke_subprocess_via_pty() -> Result<(), Box<dyn std::error::Error>> {
-    let mut ea = Command::cargo_bin("ea")?;
-    let printer_cmd = Command::cargo_bin("printfile")?;
+    let mut ea = process::Command::cargo_bin("ea")?;
+    let printer_cmd = process::Command::cargo_bin("printfile")?;
     let printer = printer_cmd.get_program();
     let input_path: PathBuf = [
         env!("CARGO_MANIFEST_DIR"),
@@ -26,7 +26,6 @@ fn invoke_subprocess_via_pty() -> Result<(), Box<dyn std::error::Error>> {
     let mut output = Vec::new();
     if let Ok(mut parent) = fork.is_parent() {
         _ = parent.read_to_end(&mut output);
-        assert!(find_subsequence(&output, b"[[0m[31m1[0m] [0m[32m20[0m:").is_some());
     } else {
         ea
             .args(["run", "grouped"])
@@ -35,6 +34,44 @@ fn invoke_subprocess_via_pty() -> Result<(), Box<dyn std::error::Error>> {
             .arg(input_path)
             .status()
             .expect("execution fails");
+        process::exit(0)
     }
+    assert!(find_subsequence(&output, b"[[0m[31m1[0m] [0m[32m20[0m:").is_some());
+    Ok(())
+}
+
+#[test]
+fn subprocess_command_error() -> Result<(), Box<dyn std::error::Error>> {
+    let mut ea = process::Command::cargo_bin("ea")?;
+    let fork = Fork::from_ptmx().unwrap();
+    let mut output = Vec::new();
+    if let Ok(mut parent) = fork.is_parent() {
+        _ = parent.read_to_end(&mut output);
+    } else {
+        ea
+            .args(["run", "rust", "cargo", "--", "clippppy"])
+            .status()
+            .expect("execution fails");
+        process::exit(0)
+    }
+    assert!(find_subsequence(&output, b"[ea]: cargo encountered an error").is_some());
+    Ok(())
+}
+
+#[test]
+fn subprocess_execution_fail() -> Result<(), Box<dyn std::error::Error>> {
+    let mut ea = process::Command::cargo_bin("ea")?;
+    let fork = Fork::from_ptmx().unwrap();
+    let mut output = Vec::new();
+    if let Ok(mut parent) = fork.is_parent() {
+        _ = parent.read_to_end(&mut output);
+    } else {
+        ea
+            .args(["run", "rust", "/lmao/i/do/not/exist"])
+            .status()
+            .expect("execution fails");
+        process::exit(0)
+    }
+    assert!(find_subsequence(&output, b"[ea]: could not execute /lmao/i/do/not/exist").is_some());
     Ok(())
 }


### PR DESCRIPTION
When error occurs, add the following at the end of child processes output:

1. exit status code (1 byte)
2. internal error code (1 byte)
3. error siginal (4 bytes, `0xdeadbeef`)

Add integration tests for child process failed execution and non-success child process exits.