### PR TITLE
Bump guard version to fix box_syntax error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "guard"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff893cc51ea04f8a3b73fbaf4376c06ebc5a0ccbe86d460896f805d9417c93ea"
+checksum = "7d7402bc4451b9f3cc9a2467bb2faf3ad01b129ae9f47f9943a24ad7a2064d84"
 
 [[package]]
 name = "hashbrown"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ lazy_static = '1.4'
 pty = '0.2'
 regex = '1'
 serde = { version = "1.0", features = ["derive"] }
-guard = '0.5.1'
+guard = '0.5.2'
 
 [build-dependencies]
 clap = { version = "3.1.8", features = ["cargo"] }


### PR DESCRIPTION
With the lastest version of the rust compiler, I am unable to build ea. The error is as follows (but I removed the duplicates that only differ by line number):
```
Checking guard v0.5.1
error: `box_syntax` has been removed
--> /Users/djm/.cargo/registry/src/index.crates.io-6f17d22bba15001f/guard-0.5.1/src/lib.rs:426:20
|
426 |         let foo = (box 42, [1, 2, 3]);
|                    ^^^^^^
|
help: use `Box::new()` instead
|
426 |         let foo = (Box::new(42), [1, 2, 3]);
|                    ~~~~~~~~~~~~
...
error: could not compile `guard` (lib) due to 4 previous errors
```
This is caused by https://github.com/rust-lang/rust/pull/108471 

This is fixed in guard 0.5.2.

I also had to fix a (seemingly) unrelated compilation issue to get it to compile, but I'll raise a separate PR for that.