### PR TITLE
Fix compilation error

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -35,7 +35,7 @@ pub fn write(list: &[Location]) -> io::Result<()> {
 
 pub fn write_to(path: &Path, list: &[Location]) -> io::Result<()> {
     let data: Vec<u8> = bincode::serialize(list).unwrap_or_default();
-    fs::write(path, &data)
+    fs::write(path, data)
 }
 
 pub fn read() -> Vec<Location> {


### PR DESCRIPTION
When trying to compile ea to test https://github.com/dduan/ea/pull/64 I also got the following error
```
Compiling ea-command v0.2.1 (/home/djm/src/ea)
error: the borrowed expression implements the required traits
--> src/archive.rs:38:21
|
38 |     fs::write(path, &data)
|                     ^^^^^ help: change this to: `data`
|
= help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
= note: `-D clippy::needless-borrow` implied by `-D warnings`

error: could not compile `ea-command` (lib) due to previous error
```

This PR fixes the error.